### PR TITLE
Fix for guild material delivery of last resource

### DIFF
--- a/Scripts/Measures/ms_BuyRawMaterialArtisan.lua
+++ b/Scripts/Measures/ms_BuyRawMaterialArtisan.lua
@@ -98,9 +98,7 @@ function Run()
 
 	--check the item
 	local ItemIndex
-	if Result == "A0" then
-		ItemIndex = 0
-	elseif Result == "A1" then
+	if Result == "A1" then
 		ItemIndex = 1
 	elseif Result == "A2" then
 		ItemIndex = 2
@@ -108,8 +106,10 @@ function Run()
 		ItemIndex = 3
 	elseif Result == "A4" then
 		ItemIndex = 4
-	else
+	elseif Result == "A5" then
 		ItemIndex = 5
+	else
+		ItemIndex = 6
 	end
 
 	local Object = ItemGetName(items[ItemIndex]).."Box"..box

--- a/Scripts/Measures/ms_BuyRawMaterialChiseler.lua
+++ b/Scripts/Measures/ms_BuyRawMaterialChiseler.lua
@@ -106,16 +106,16 @@ function Run()
 
 	--check the item
 	local ItemIndex
-	if Result == "A0" then
-		ItemIndex = 0
-	elseif Result == "A1" then
+	if Result == "A1" then
 		ItemIndex = 1
 	elseif Result == "A2" then
 		ItemIndex = 2
 	elseif Result == "A3" then
 		ItemIndex = 3
-	else
+	elseif Result == "A4" then
 		ItemIndex = 4
+	else
+		ItemIndex = 5
 	end
 
 	local Object = ItemGetName(items[ItemIndex]).."Box"..box

--- a/Scripts/Measures/ms_BuyRawMaterialPatron.lua
+++ b/Scripts/Measures/ms_BuyRawMaterialPatron.lua
@@ -100,9 +100,7 @@ function Run()
 
 	--check the item
 	local ItemIndex
-	if Result == "A0" then
-		ItemIndex = 0
-	elseif Result == "A1" then
+	if Result == "A1" then
 		ItemIndex = 1
 	elseif Result == "A2" then
 		ItemIndex = 2
@@ -110,8 +108,10 @@ function Run()
 		ItemIndex = 3
 	elseif Result == "A4" then
 		ItemIndex = 4
-	else
+	elseif Result == "A5" then
 		ItemIndex = 5
+	else
+		ItemIndex = 6
 	end
 
 	local Object = ItemGetName(items[ItemIndex]).."Box"..box

--- a/Scripts/Measures/ms_BuyRawMaterialScholar.lua
+++ b/Scripts/Measures/ms_BuyRawMaterialScholar.lua
@@ -100,14 +100,14 @@ function Run()
 
 	--check the item
 	local ItemIndex
-	if Result == "A0" then
-		ItemIndex = 0
-	elseif Result == "A1" then
+	if Result == "A1" then
 		ItemIndex = 1
 	elseif Result == "A2" then
 		ItemIndex = 2
-	else
+	elseif Result == "A3" then
 		ItemIndex = 3
+	else
+		ItemIndex = 4
 	end
 
 	local Object = ItemGetName(items[ItemIndex]).."Box"..box


### PR DESCRIPTION
In vanilla and probably in this mod you can't buy the last resource a guild house offers. So for example a Scholar can not buy Leather, instead Wool will be offered.

I did not test this, don't know if you already fixed it elsewhere but if in your mod you too can't buy the rightmost resource delivery then this should fix it.

The bug was simply that the ItemIndex started from 0 while the items array is numbered from 1. Will break again if you add another resource but since this is just bugfix mod it should not matter.
Sorry for 4 commits, made from github web UI.
